### PR TITLE
Add missing colon-prefixed module files

### DIFF
--- a/srfi-lib/srfi/%3a30.rkt
+++ b/srfi-lib/srfi/%3a30.rkt
@@ -1,0 +1,1 @@
+#lang s-exp srfi/provider srfi/30

--- a/srfi-lib/srfi/%3a34.rkt
+++ b/srfi-lib/srfi/%3a34.rkt
@@ -1,0 +1,1 @@
+#lang s-exp srfi/provider srfi/34

--- a/srfi-lib/srfi/%3a35.rkt
+++ b/srfi-lib/srfi/%3a35.rkt
@@ -1,0 +1,1 @@
+#lang s-exp srfi/provider srfi/35

--- a/srfi-lib/srfi/%3a4.rkt
+++ b/srfi-lib/srfi/%3a4.rkt
@@ -1,0 +1,1 @@
+#lang s-exp srfi/provider srfi/4

--- a/srfi-lib/srfi/%3a40.rkt
+++ b/srfi-lib/srfi/%3a40.rkt
@@ -1,0 +1,1 @@
+#lang s-exp srfi/provider srfi/40

--- a/srfi-lib/srfi/%3a62.rkt
+++ b/srfi-lib/srfi/%3a62.rkt
@@ -1,0 +1,1 @@
+#lang s-exp srfi/provider srfi/62


### PR DESCRIPTION
Some `%3a*.rkt` files seem to be unintentionally omitted. I noticed this because we rely on these files' presence to generate a list of SRFIs supported by Racket and these SRFIs don't appear on the generated list.